### PR TITLE
fix small bug on Calibrations.start()

### DIFF
--- a/src/echelle_spectra/tools/echelle.py
+++ b/src/echelle_spectra/tools/echelle.py
@@ -532,7 +532,7 @@ class Calibrations:
 
         spectra_shapes = np.array([s.shape[0] for s in self.sphr.order_spectra[0]])
         lambda_shapes = np.array([ow.shape[0] for ow in self.order_wavel])
-        wrong_shapes = spectra_shapes - lambda_shapes
+        wrong_shapes = np.setdiff1d(spectra_shapes, lambda_shapes)
         wrong_shapes = np.where(wrong_shapes != 0)[0]
 
         froms = []


### PR DESCRIPTION
src/echelle_spectra/examples/3.3_Wavelength_Calibration.ipynbについて

`cb = Calibrations(folder,files_niihama,spec='fujii',dv=17,crop=crop,exptime=0.1)
cb.start()`

を実行すると以下のエラーが出るので修正した

```content/echelle_spectra/src/echelle_spectra/tools/echelle.py in wavelength_calibration(self, **kws)
    533         spectra_shapes = np.array([s.shape[0] for s in self.sphr.order_spectra[0]])
    534         lambda_shapes = np.array([ow.shape[0] for ow in self.order_wavel])
--> 535         wrong_shapes = spectra_shapes - lambda_shapes
    536         wrong_shapes = np.where(wrong_shapes != 0)[0]
    537 

ValueError: operands could not be broadcast together with shapes (35,) (13,) 
```